### PR TITLE
[#46] 예외 누락 파일 추가

### DIFF
--- a/cinema-common/src/main/java/com/ureca/common/exception/SeatReservedException.java
+++ b/cinema-common/src/main/java/com/ureca/common/exception/SeatReservedException.java
@@ -1,0 +1,7 @@
+package com.ureca.common.exception;
+
+public class SeatReservedException extends RuntimeException {
+    public SeatReservedException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## Issue No
- close #46

## Overview
- 좌석 선택 예외 코드 누락해서 추가합니다.
- 원래는 프론트에서 좌석 예매 여부 확인해야 되는건데, 프론트 로직 못짜서 뒷단에서 예외 메세지 날리게 했습니다. 로그 확인용이라 크게 기능적으로 신경쓰지 않으셔도 됩니다!
